### PR TITLE
feat: Add container + pod metrics

### DIFF
--- a/charts/aspenmesh-collector/templates/clusterrole.yaml
+++ b/charts/aspenmesh-collector/templates/clusterrole.yaml
@@ -14,6 +14,7 @@ rules:
     - endpoints
     - pods
     - configmaps
+    - namespaces
   verbs:
       - get
       - list

--- a/charts/aspenmesh-collector/templates/configmap.yaml
+++ b/charts/aspenmesh-collector/templates/configmap.yaml
@@ -25,6 +25,24 @@ data:
                 action: keep
                 regex: '.*-envoy-prom'
     processors:
+      k8sattributes:
+        auth_type: "serviceAccount"
+        passthrough: false
+        extract:
+          metadata:
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.deployment.name
+            - k8s.namespace.name
+            - k8s.node.name
+            - k8s.pod.start_time
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.ip
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
       resourcedetection/eks:
         detectors: [env, eks]
         timeout: 2s
@@ -54,6 +72,7 @@ data:
             - otlp
             - prometheus
           processors:
+            - k8sattributes
             - resourcedetection/eks
             - resourcedetection/aks
             - resourcedetection/gke


### PR DESCRIPTION
Adding support for container and pod metrics via the `kubeletstats` receiver from the agent. 

Used `metric_groups` to limit the metrics return to only `container.*` and `k8s.pod.*`